### PR TITLE
Upgrade tox to latest: 3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN curl -fsSLo /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/r
   && chmod 755 /opt/geckodriver-$GECKODRIVER_VERSION \
   && ln -fs /opt/geckodriver-$GECKODRIVER_VERSION /usr/bin/geckodriver
 
-ENV TOX_VERSION=2.9.1
+ENV TOX_VERSION=3.0.0
 RUN pip3 install tox==$TOX_VERSION
 
 ADD . /src


### PR DESCRIPTION
@kimberlythegeek r?

Passing stuff here:

```
To https://github.com/stephendonner/axe-selenium-python
 * [new branch]      tox-3.0.0 -> tox-3.0.0
Stephens-MacBook-Pro:axe-selenium-python stephendonner$ docker build -t axe-selenium-python .
Sending build context to Docker daemon  961.5kB
Step 1/11 : FROM ubuntu:xenial
 ---> f975c5035748
Step 2/11 : ENV DEBIAN_FRONTEND=noninteractive   MOZ_HEADLESS=1   PIP_DISABLE_PIP_VERSION_CHECK=1
 ---> Using cache
 ---> ef874440aadf
Step 3/11 : RUN apt-get update   && apt-get install -y software-properties-common   && add-apt-repository ppa:deadsnakes/ppa   && apt-get update   && apt-get install -y bzip2 curl firefox git python2.7 python3.6 python3-pip   && rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 30ddd3983329
Step 4/11 : ENV FIREFOX_VERSION=59.0
 ---> Using cache
 ---> 7544b7d62e9c
Step 5/11 : RUN curl -fsSLo /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2   && apt-get -y purge firefox   && rm -rf /opt/firefox   && tar -C /opt -xjf /tmp/firefox.tar.bz2   && rm /tmp/firefox.tar.bz2   && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION   && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
 ---> Using cache
 ---> c391b19a53c0
Step 6/11 : ENV GECKODRIVER_VERSION=0.20.0
 ---> Using cache
 ---> 98e560e0ef98
Step 7/11 : RUN curl -fsSLo /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz   && rm -rf /opt/geckodriver   && tar -C /opt -zxf /tmp/geckodriver.tar.gz   && rm /tmp/geckodriver.tar.gz   && mv /opt/geckodriver /opt/geckodriver-$GECKODRIVER_VERSION   && chmod 755 /opt/geckodriver-$GECKODRIVER_VERSION   && ln -fs /opt/geckodriver-$GECKODRIVER_VERSION /usr/bin/geckodriver
 ---> Using cache
 ---> 0aaedfde8971
Step 8/11 : ENV TOX_VERSION=3.0.0
 ---> Using cache
 ---> 6fd13530d7fe
Step 9/11 : RUN pip3 install tox==$TOX_VERSION
 ---> Using cache
 ---> 23d22ee02dbb
Step 10/11 : ADD . /src
 ---> 19c8fd3f9f99
Step 11/11 : WORKDIR /src
Removing intermediate container 841444d13244
 ---> 94a26fcc950d
Successfully built 94a26fcc950d
Successfully tagged axe-selenium-python:latest
Stephens-MacBook-Pro:axe-selenium-python stephendonner$ docker run -t axe-selenium-python tox
py27 create: /src/.tox/py27
py27 installdeps: -raxe_selenium_python/tests/requirements/tests.txt
py27 installed: attrs==17.4.0,certifi==2018.1.18,chardet==3.0.4,funcsigs==1.0.2,idna==2.6,more-itertools==4.1.0,pluggy==0.6.0,py==1.5.3,pytest==3.5.0,pytest-base-url==1.4.1,pytest-html==1.16.1,pytest-metadata==1.6.0,pytest-selenium==1.12.0,pytest-variables==1.7.1,requests==2.18.4,selenium==3.11.0,six==1.11.0,urllib3==1.22
py27 runtests: PYTHONHASHSEED='368115875'
py27 runtests: commands[0] | pytest
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.5.0, py-1.5.3, pluggy-0.6.0 -- /src/.tox/py27/bin/python2.7
cachedir: .pytest_cache
driver: Firefox
sensitiveurl: .* *** WARNING: sensitive url matches https://web-mozillians-staging.production.paas.mozilla.community ***
metadata: {'Platform': 'Linux-4.9.87-linuxkit-aufs-x86_64-with-Ubuntu-16.04-xenial', 'Base URL': 'https://web-mozillians-staging.production.paas.mozilla.community', 'Python': '2.7.12', 'Packages': {'py': '1.5.3', 'pluggy': '0.6.0', 'pytest': '3.5.0'}, 'Plugins': {'html': '1.16.1', 'base-url': '1.4.1', 'variables': '1.7.1', 'metadata': '1.6.0', 'selenium': '1.12.0'}, 'Capabilities': {}, 'Driver': 'Firefox'}
baseurl: https://web-mozillians-staging.production.paas.mozilla.community
rootdir: /src, inifile: tox.ini
plugins: variables-1.7.1, selenium-1.12.0, metadata-1.6.0, html-1.16.1, base-url-1.4.1
collected 3 items                                                              

axe_selenium_python/tests/test_axe.py::test_execute PASSED               [ 33%]
axe_selenium_python/tests/test_axe.py::test_report PASSED                [ 66%]
axe_selenium_python/tests/test_axe.py::test_write_results PASSED         [100%]

========================== 3 passed in 19.55 seconds ===========================
py36 create: /src/.tox/py36
py36 installdeps: -raxe_selenium_python/tests/requirements/tests.txt
py36 installed: attrs==17.4.0,certifi==2018.1.18,chardet==3.0.4,idna==2.6,more-itertools==4.1.0,pluggy==0.6.0,py==1.5.3,pytest==3.5.0,pytest-base-url==1.4.1,pytest-html==1.16.1,pytest-metadata==1.6.0,pytest-selenium==1.12.0,pytest-variables==1.7.1,requests==2.18.4,selenium==3.11.0,six==1.11.0,urllib3==1.22
py36 runtests: PYTHONHASHSEED='368115875'
py36 runtests: commands[0] | pytest
============================= test session starts ==============================
platform linux -- Python 3.6.4, pytest-3.5.0, py-1.5.3, pluggy-0.6.0 -- /src/.tox/py36/bin/python3.6
cachedir: .pytest_cache
driver: Firefox
sensitiveurl: .* *** WARNING: sensitive url matches https://web-mozillians-staging.production.paas.mozilla.community ***
metadata: {'Python': '3.6.4', 'Platform': 'Linux-4.9.87-linuxkit-aufs-x86_64-with-Ubuntu-16.04-xenial', 'Packages': {'pytest': '3.5.0', 'py': '1.5.3', 'pluggy': '0.6.0'}, 'Plugins': {'variables': '1.7.1', 'selenium': '1.12.0', 'metadata': '1.6.0', 'html': '1.16.1', 'base-url': '1.4.1'}, 'Base URL': 'https://web-mozillians-staging.production.paas.mozilla.community', 'Driver': 'Firefox', 'Capabilities': {}}
baseurl: https://web-mozillians-staging.production.paas.mozilla.community
rootdir: /src, inifile: tox.ini
plugins: variables-1.7.1, selenium-1.12.0, metadata-1.6.0, html-1.16.1, base-url-1.4.1
collected 3 items                                                              

axe_selenium_python/tests/test_axe.py::test_execute PASSED               [ 33%]
axe_selenium_python/tests/test_axe.py::test_report PASSED                [ 66%]
axe_selenium_python/tests/test_axe.py::test_write_results PASSED         [100%]

========================== 3 passed in 18.50 seconds ===========================
flake8 create: /src/.tox/flake8
flake8 installdeps: -raxe_selenium_python/tests/requirements/flake8.txt
flake8 installed: flake8==3.5.0,mccabe==0.6.1,pycodestyle==2.3.1,pyflakes==1.6.0
flake8 runtests: PYTHONHASHSEED='368115875'
flake8 runtests: commands[0] | flake8 .
___________________________________ summary ____________________________________
  py27: commands succeeded
  py36: commands succeeded
  flake8: commands succeeded
  congratulations :)
```