### PR TITLE
Add python-dev to Dockerfile to 'fix' python2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
   && apt-get install -y software-properties-common \
   && add-apt-repository ppa:deadsnakes/ppa \
   && apt-get update \
-  && apt-get install -y bzip2 curl firefox git python2.7 python3.6 python3-pip \
+  && apt-get install -y bzip2 curl firefox git python2.7 python-dev python3.6 python3-pip \
   && rm -rf /var/lib/apt/lists/*
 
 ENV FIREFOX_VERSION=61.0


### PR DESCRIPTION
Something seems to have changed in either ubuntu:xenial or perhaps (more likely) one of these python packages (probably ```python2.7```): https://github.com/mozilla-services/axe-selenium-python/blob/b4eb94915a5deb67bd9cce94cc3b0e9ab0ee2b02/Dockerfile#L11

See https://stackoverflow.com/questions/21530577/fatal-error-python-h-no-such-file-or-directory