### PR TITLE
Replaced unit tests with more meaningful integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ __pycache__
 .cache/
 .tox
 *.log
-*.html
 assets/
 *.json
 build/

--- a/axe_selenium_python/axe.py
+++ b/axe_selenium_python/axe.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
+from io import open
 from os import path
 
 _DEFAULT_SCRIPT = path.join(path.dirname(__file__), 'src', 'axe.min.js')
@@ -21,7 +22,7 @@ class Axe(object):
         :param script_url: location of the axe-core script.
         :type script_url: string
         """
-        with open(self.script_url) as f:
+        with open(self.script_url, 'r', encoding='utf8') as f:
             self.selenium.execute_script(f.read())
 
     def execute(self, context=None, options=None):
@@ -81,12 +82,12 @@ class Axe(object):
             string += '\n\n\n'
         return string
 
-    def write_results(self, name, output):
+    def write_results(self, data, name='results.json'):
         """
         Write JSON to file with the specified name.
 
         :param name: Name of file to be written to.
         :param output: JSON object.
         """
-        with open(name, 'w+') as f:
-            f.write(json.dumps(output, indent=4))
+        with open(name, 'r', encoding='utf8') as f:
+            f.write(json.dumps(data, indent=4))

--- a/axe_selenium_python/tests/conftest.py
+++ b/axe_selenium_python/tests/conftest.py
@@ -2,27 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import os
 from datetime import datetime
 
 import pytest
-from axe_selenium_python import Axe
 from py.xml import html
-
-_DEFAULT_SCRIPT = os.path.join(os.path.dirname(__file__), 'src', 'axe.min.js')
-
-
-@pytest.fixture
-def script_url():
-    """Return a script URL."""
-    return _DEFAULT_SCRIPT
-
-
-@pytest.fixture(scope='function')
-def axe(selenium, base_url, script_url):
-    """Return an Axe instance based on context and options."""
-    selenium.get(base_url)
-    yield Axe(selenium, script_url)
 
 
 @pytest.mark.optionalhook

--- a/axe_selenium_python/tests/requirements/tests.txt
+++ b/axe_selenium_python/tests/requirements/tests.txt
@@ -1,5 +1,3 @@
 pytest==3.7.1
 selenium==3.14.0
-pytest-selenium==1.13.0
 pytest-html==1.19.0
-pytest_base_url==1.4.1

--- a/axe_selenium_python/tests/test_page.html
+++ b/axe_selenium_python/tests/test_page.html
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <form action='#'>
+      <input type='text'/>
+      <select name='' id=''>
+        <option value=''>one</option>
+        <option value=''>two</option>
+        <option value=''>three</option>
+        <option value=''>four</option>
+      </select>
+    </form>
+    <ul>
+      <div>
+        <li>This is a line element</li>
+      </div>
+    </ul>
+  </body>
+</html>

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def readme():
 
 
 setup(name='axe-selenium-python',
-      version='2.0.4',
+      version='2.0.5',
       description='Python library to integrate axe and selenium for web \
                 accessibility testing.',
       long_description=readme(),

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,3 @@ ignore = E501
 default_section = THIRDPARTY
 known_first_party = axe-selenium-python
 skip = build, .tox
-
-[pytest]
-addopts = --verbose --driver=Firefox
-base_url = https://web-mozillians-staging.production.paas.mozilla.community


### PR DESCRIPTION
Rather than using unit tests, which are essentially testing the axe API and not this package, I have replaced them with (so far) two integration tests.

These tests run axe against a sample page and verify the response is as expected.

I have added a test case for Chrome, as it has been brought to our attention that, currently, `axe.execute()` returns an empty dictionary when used in Chrome. See #118 