### PR TITLE
fix 'writing results to file' method

### DIFF
--- a/axe_selenium_python/axe.py
+++ b/axe_selenium_python/axe.py
@@ -100,5 +100,5 @@ class Axe(object):
         :param name: Name of file to be written to.
         :param output: JSON object.
         """
-        with open(name, "r", encoding="utf8") as f:
+        with open(name, "w", encoding="utf8") as f:
             f.write(json.dumps(data, indent=4))

--- a/axe_selenium_python/tests/test_axe.py
+++ b/axe_selenium_python/tests/test_axe.py
@@ -4,7 +4,9 @@
 
 from os import path, getenv
 
-import json, pytest
+import json
+import pytest
+from unittest import mock
 from selenium import webdriver
 
 from ..axe import Axe
@@ -73,8 +75,8 @@ def tempdir():
     shutil.rmtree(new_dir)
 
 
-def test_write_results_to_file(firefox_driver, tempdir):
-    axe = Axe(firefox_driver)
+def test_write_results_to_file(tempdir):
+    axe = Axe(mock.MagicMock())
     data = json.dumps({"testKey": "testValue"})
     filename = path.join(tempdir, "results.json")
 

--- a/axe_selenium_python/tests/test_axe.py
+++ b/axe_selenium_python/tests/test_axe.py
@@ -4,7 +4,7 @@
 
 from os import path, getenv
 
-import pytest
+import json, pytest
 from selenium import webdriver
 
 from ..axe import Axe
@@ -62,3 +62,25 @@ def _perform_axe_run(driver):
     axe.inject()
     data = axe.execute()
     return data
+
+
+@pytest.fixture
+def tempdir():
+    import tempfile
+    import shutil
+    new_dir = tempfile.mkdtemp()
+    yield new_dir
+    shutil.rmtree(new_dir)
+
+
+def test_write_results_to_file(firefox_driver, tempdir):
+    axe = Axe(firefox_driver)
+    data = json.dumps({"testKey": "testValue"})
+    filename = path.join(tempdir, "results.json")
+
+    axe.write_results(data=data, name=filename)
+
+    with open(filename) as f:
+        actual_file_contents = json.loads(f.read())
+
+    assert data == actual_file_contents


### PR DESCRIPTION
Writing results to a file was not possible due to a typo in the file opening permissions.