### PR TITLE
change def axe.execute() to axe.run() to mirror axe-core naming

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,14 +62,14 @@ Usage
       # Inject axe-core javascript into page.
       axe.inject()
       # Run axe accessibility checks.
-      results = axe.execute()
+      results = axe.run()
       # Write results to file
       axe.write_results(results, 'a11y.json')
       driver.close()
       # Assert no violations are found
       assert len(results["violations"]) == 0, axe.report(results["violations"])
 
-The method ``axe.execute()`` accepts two parameters: ``context`` and ``options``.
+The method ``axe.run()`` accepts two parameters: ``context`` and ``options``.
 
 For more information on ``context`` and ``options``, view the `aXe documentation here <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#parameters-axerun>`_.
 

--- a/axe_selenium_python/axe.py
+++ b/axe_selenium_python/axe.py
@@ -26,7 +26,7 @@ class Axe(object):
         with open(self.script_url, "r", encoding="utf8") as f:
             self.selenium.execute_script(f.read())
 
-    def execute(self, context=None, options=None):
+    def run(self, context=None, options=None):
         """
         Run axe against the current page.
 

--- a/axe_selenium_python/tests/test_axe.py
+++ b/axe_selenium_python/tests/test_axe.py
@@ -61,7 +61,7 @@ def _perform_axe_run(driver):
     driver.get("file://" + _DEFAULT_TEST_FILE)
     axe = Axe(driver)
     axe.inject()
-    data = axe.execute()
+    data = axe.run()
     return data
 
 


### PR DESCRIPTION
Renamed execute() in axe.py to run() to mirror [axe-core API's naming of the function](https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axerun).

Also updated README to use new axe.run() function name in documentation, and the function call in the _perform_axe_run() test so the test suite didn't think the code had burst into flame.

fixes #160 