### PR TITLE
Update README.rst and axe_selenium_python/package-lock.json from axe-…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ axe-selenium-python
 
 axe-selenium-python integrates aXe and selenium to enable automated web accessibility testing.
 
-**This version of axe-selenium-python is using axe-core@3.1.1.**
+**This version of axe-selenium-python is using axe-core@3.1.2.**
 
 .. image:: https://img.shields.io/badge/license-MPL%202.0-blue.svg
    :target: https://github.com/mozilla-services/axe-selenium-python/blob/master/LICENSE.txt

--- a/axe_selenium_python/package-lock.json
+++ b/axe_selenium_python/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "axe-core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.1.1.tgz",
-      "integrity": "sha512-5/JPwRqOMDnEqonolatT9/i+aOTYCpTEHR4rqmYjWRn+oiZdRHbYv8MC+HNLEtP0I3mkC3glAF8fRkfKHrUOtw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.1.2.tgz",
+      "integrity": "sha512-e1WVs0SQu3tM29J9a/mISGvlo2kdCStE+yffIAJF6eb42FS+eUFEVz9j4rgDeV2TAfPJmuOZdRetWYycIbK7Vg=="
     }
   }
 }


### PR DESCRIPTION
Updated README.rst and axe_selenium_python/package-lock.json from axe-core 3.1.1 to 3.1.2, using "integrity" value copied from https://github.com/pa11y/pa11y-runner-axe/blob/master/package-lock.json

I copied https://cdnjs.cloudflare.com/ajax/libs/axe-core/3.1.2/axe.min.js to my local axe-selenium-python\axe_selenium_python\node_modules\axe-core\min.js.

And I tested with tox, but using just Python 3.7 (what I have installed) rather than both Python 2.7 and Python 3.6, by making a minor change to my local tox.ini file:
@@ -1,7 +1,7 @@
 [tox]
-envlist = py27, py36, flake8
+envlist = py37, flake8

The axe tests passed, but there were some complaints from flake8:
c:\projects\python\selenium\axe-selenium-python\.tox\flake8\lib\site-packages\pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
.\setup.py:3:1: I001 isort found an import in the wrong position
.\setup.py:5:1: I003 isort expected 1 blank line in imports, found 0
...

Most of them seem similar to closed issue https://github.com/gforcada/flake8-isort/issues/65, which I don't understand since I'm running the latest version of flake8.
But I don't think that's related to my changes.
I've attached a copy of the tox output.
[tox.log](https://github.com/mozilla-services/axe-selenium-python/files/2641736/tox.log)

