### PR TITLE
include license in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README.rst axe_selenium_python/node_modules/axe-core/axe.min.js axe_selenium_python/tests/test_page.html
+include LICENSES.txt README.rst axe_selenium_python/node_modules/axe-core/axe.min.js axe_selenium_python/tests/test_page.html
 recursive-include *.rst *.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include LICENSES.txt README.rst axe_selenium_python/node_modules/axe-core/axe.min.js axe_selenium_python/tests/test_page.html
+include LICENSE.txt README.rst axe_selenium_python/node_modules/axe-core/axe.min.js axe_selenium_python/tests/test_page.html
 recursive-include *.rst *.txt


### PR DESCRIPTION
Hello, and thank you _so_ much for `axe-selenium-python` :tada:!

This PR just ensures that the LICENSE file is included in the `sdist` output.

I'm looking to package this for `conda-forge`, and while this isn't a blocker (i can grab it from `master`) having it in a single file would be lovely! Ideally it would _also_ include the license for the `axe.*.js` files, but that's for another day!